### PR TITLE
Implement a SMTP relay

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executable
  (name mti_pf)
- (libraries sage.lwt nocrypto.lwt logs.fmt fpath bos rresult mtime mtime.clock.os lwt.unix dns-client.lwt lwt ptt))
+ (libraries mrmime tcpip.stack-socket tuyau.mirage.tcp tuyau.mirage.tls logs.fmt colombe.emile colombe.received fpath bos rresult ptime ptime.clock.os mtime mtime.clock.os dns-client.mirage nocrypto.lwt lwt ptt))

--- a/bin/lwt_backend.ml
+++ b/bin/lwt_backend.ml
@@ -31,3 +31,9 @@ module Lwt_io = struct
   let bind = Lwt.bind
   let return = Lwt.return
 end
+
+let lwt =
+  let open Lwt.Infix in
+  let open Lwt_scheduler in
+  { Colombe.Sigs.bind= (fun x f -> inj (prj x >>= fun x -> prj (f x)))
+  ; Colombe.Sigs.return= (fun x -> inj (Lwt.return x)) }

--- a/bin/mti_pf.ml
+++ b/bin/mti_pf.ml
@@ -8,29 +8,290 @@ let () = Logs.set_level ~all:true (Some Logs.Debug)
 let () = Logs.set_reporter reporter
 
 let ( <.> ) f g = fun x -> f (g x)
+let apply x f = f x
 
 open Lwt_backend
+open Rresult
+open Lwt.Infix
 
 module Relay = Ptt.Relay.Make(Lwt_scheduler)(Lwt_io)
 
-let resolver =
-  { Relay.gethostbyname= (fun w v -> Dns_client_lwt.gethostbyname w v)
-  ; Relay.extension= (fun _ldh _v -> Lwt.return (Rresult.R.error_msgf "Impossible to resolver [%s:%s]" _ldh _v)) }
+module Relay_map = struct
+end
 
-let rdwr =
-  { Colombe.Sigs.rd= (fun flow buf off len ->
-        let fiber =
-          let open Lwt.Infix in
-          Lwt_unix.read flow buf off len >>= fun len ->
-          Fmt.epr "-> read %d byte(s): %S.\n%!" len (Bytes.sub_string buf off len) ;
-          Lwt.return len in
-        Lwt_scheduler.inj fiber)
-  ; Colombe.Sigs.wr= (fun flow buf off len ->
-        let buf = Bytes.unsafe_of_string buf in
-        let fiber =
-          let open Lwt.Infix in
-          Lwt_unix.write flow buf off len >>= fun _len -> Lwt.return () in
-        Lwt_scheduler.inj fiber) }
+module Mxs = Ptt.Mxs
+module By_domain = Ptt.Aggregate.By_domain
+module By_ipaddr = Ptt.Aggregate.By_ipaddr
+
+type resolved =
+  | Ipaddr of Ipaddr.t
+  | Domain of [ `host ] Domain_name.t * Mxs.t
+
+module Resolved = Map.Make(struct
+    type t = resolved
+
+    let compare a b = match a, b with
+      | Ipaddr a, Ipaddr b -> Ipaddr.compare a b
+      | Domain (_, mxs_a), Domain (_, mxs_b) ->
+        let { Mxs.mx_ipaddr= a; _ } = Mxs.choose mxs_a in
+        let { Mxs.mx_ipaddr= b; _ } = Mxs.choose mxs_b in
+        Ipaddr.compare a b
+      | Ipaddr a, Domain (_, mxs) ->
+        let { Mxs.mx_ipaddr= b; _ } = Mxs.choose mxs in
+        Ipaddr.compare a b
+      | Domain (_, mxs), Ipaddr b ->
+        let { Mxs.mx_ipaddr= a; _ } = Mxs.choose mxs in
+        Ipaddr.compare a b
+  end)
+
+module Mclock = struct
+  let elapsed_ns = Mtime_clock.elapsed_ns
+  let period_ns = Mtime_clock.period_ns
+end
+
+module Random = struct
+  type g = unit
+
+  let generate ?g:_ len =
+    let ic = open_in "/dev/urandom" in
+    let rs = Bytes.create len in
+    really_input ic rs 0 len ; close_in ic ;
+    Cstruct.of_bytes rs
+end
+
+module Make (StackV4 : Mirage_stack.V4) = struct
+  module TCP = Tuyau_mirage_tcp.Make(StackV4)
+  module TLS = Tuyau_mirage_tls
+  module DNS = Dns_client_mirage.Make(Random)(Mclock)(StackV4)
+
+  let src = Logs.Src.create "MTI-PF"
+  module Log = ((val Logs.src_log src) : Logs.LOG)
+
+  let tls_endpoint, tls_protocol = TLS.protocol_with_tls ~key:TCP.endpoint TCP.protocol
+  let tls_configuration, tls_service = TLS.service_with_tls ~key:TCP.configuration TCP.service tls_protocol
+
+  let ( >>? ) x f = x >>= function
+    | Ok x -> f x
+    | Error err -> Lwt.return (Error err)
+
+  let ( >|? ) x f = x >>= function
+    | Ok x -> Lwt.return (f x)
+    | Error err -> Lwt.return (Error err)
+
+  let dns_impl =
+    { Relay.gethostbyname= (fun w v -> DNS.gethostbyname w v)
+    ; Relay.getmxbyname= (fun w v -> DNS.getaddrinfo w Dns.Rr_map.Mx v >>= function
+        | Ok (_, v) -> Lwt.return (Ok v)
+        | Error _ as err -> Lwt.return err)
+    ; Relay.extension= (fun _ldh _v -> Lwt.return (Rresult.R.error_msgf "Impossible to resolve [%s:%s]" _ldh _v)) }
+
+  let failwithf fmt = Fmt.kstrf (fun err -> Failure err) fmt
+
+  let rdwr_of_flow
+    : type flow. (module Tuyau_mirage.FLOW with type flow = flow) -> (flow, Lwt_scheduler.t) Colombe.Sigs.rdwr
+    = fun (module Flow) ->
+      (* XXX(dinosaure): we must use [Cstruct.t] instead [Bytes.t] at the end. *)
+    let ic_raw = Cstruct.create 0x1000 in
+    let oc_raw = Cstruct.create 0x1000 in
+    let rd flow buf off len =
+      let len = min len (Cstruct.len ic_raw) in
+      let ic_raw = Cstruct.sub ic_raw 0 len in
+      let rec fiber = function
+        | Ok `End_of_input -> Lwt.return 0
+        | Ok (`Input 0) -> Flow.recv flow ic_raw >>= fiber
+        | Ok (`Input len) ->
+          Cstruct.blit_to_bytes ic_raw 0 buf off len ;
+          Lwt.return len
+        | Error err -> Lwt.fail (failwithf "%a" Flow.pp_error err) in
+      Lwt_scheduler.inj (Flow.recv flow ic_raw >>= fiber) in
+    let rec wr flow buf off len =
+      let n = min len (Cstruct.len oc_raw) in
+      Cstruct.blit_from_string buf off oc_raw 0 n ;
+      Flow.send flow (Cstruct.sub oc_raw 0 n) >>= function
+      | Ok n ->
+        if n = len then Lwt.return () else wr flow buf (off + n) (len - n)
+      | Error err -> Lwt.fail (failwithf "%a" Flow.pp_error err) in
+    let wr flow buf off len = Lwt_scheduler.inj (wr flow buf off len) in
+    { Colombe.Sigs.rd; Colombe.Sigs.wr; }
+
+  let plug_consumer_to_producers consumer producers =
+    let rec go () = consumer () >>= function
+      | Some v ->
+        List.iter (fun producer -> producer (Some v)) producers ; Lwt.pause () >>= go
+      | None ->
+        List.iter (fun producer -> producer None) producers ; Lwt.return () in
+    go
+
+  let sendmail stack conf_server mx_ipaddr emitter producer recipients =
+    let endpoint =
+      { Tuyau_mirage_tcp.stack= stack
+      ; Tuyau_mirage_tcp.keepalive= None
+      ; Tuyau_mirage_tcp.ip= mx_ipaddr
+      ; Tuyau_mirage_tcp.port= 25 } in
+    Tuyau_mirage.flow_of_protocol ~key:TCP.endpoint endpoint ~protocol:TCP.protocol >>? fun flow ->
+    let ctx = Sendmail_with_tls.Context_with_tls.make () in
+    let rdwr = rdwr_of_flow (Tuyau_mirage.impl_of_flow TCP.protocol) in
+    let tls = Tls.Config.client ~authenticator:X509.Authenticator.null () in
+    let domain =
+      let vs = Domain_name.to_strings (Relay.info conf_server).Ptt.SMTP.domain in
+      Colombe.Domain.Domain vs in
+    Lwt.catch
+      (fun () ->
+         Sendmail_with_tls.sendmail lwt rdwr flow ctx tls ~domain emitter recipients producer
+         |> Lwt_scheduler.prj >|= R.reword_error (fun err -> `Sendmail err))
+      (function Failure err -> Lwt.return (R.error_msg err) (* XXX(dinosaure): should come from [rdwr]. *)
+              | exn -> Lwt.return (Error (`Exn exn))) >>= function
+    | Ok () -> Lwt.return (Ok ())
+    | Error (`Sendmail err) ->
+      Lwt.return (R.error_msgf "%a" Sendmail_with_tls.pp_error err)
+    | Error (`Msg _) as err ->
+      Lwt.return err
+    | Error (`Exn exn) ->
+      Log.err (fun m -> m "Got an exception: %s" (Printexc.to_string exn)) ;
+      Lwt.return (Error (`Msg "Unknown exception"))
+
+  let transmit stack resolver conf_server map (key, queue, consumer) =
+    let info = Relay.info conf_server in
+    let impl = Relay.resolver conf_server in
+    let unresolved, resolved =
+      Ptt.Messaged.recipients key |> List.map fst |>
+      Ptt.Aggregate.aggregate_by_domains ~domain:info.Ptt.SMTP.domain in
+    let unresolved, resolved = Ptt.Relay_map.expand map unresolved resolved in
+    let fold resolved (domain, v) =
+      impl.getmxbyname resolver domain >>= function
+      | Error (`Msg err) ->
+        Log.err (fun m -> m "Domain %a does not have a Mail Exchange service: %s" Domain_name.pp domain err) ;
+        Lwt.return resolved
+      | Ok set ->
+        let fold mxs { Dns.Mx.mail_exchange; Dns.Mx.preference; } =
+          impl.gethostbyname resolver mail_exchange >>= function
+          | Ok mx_ipaddr -> Lwt.return Mxs.(add (v ~preference ~domain:mail_exchange (Ipaddr.V4 mx_ipaddr)) mxs)
+          | Error (`Msg err) ->
+            Log.warn (fun m -> m "Impossible to reach the Mail Exchange service %a: %s" Domain_name.pp mail_exchange err ) ;
+            Lwt.return mxs in
+        Lwt_list.fold_left_s fold Mxs.empty (Dns.Rr_map.Mx_set.elements set) >>= fun mxs ->
+        if Mxs.is_empty mxs
+        then ( Log.err (fun m -> m "Domain %a does not have a reachable Mail Exchange service." Domain_name.pp domain )
+             ; Lwt.return resolved )
+        else
+          let postmaster = [ `Atom "Postmaster" ] in
+          let { Mxs.mx_ipaddr; _ } = Mxs.choose mxs in
+          match v with
+          | `All -> Lwt.return (Resolved.add (Domain (domain, mxs)) `All resolved)
+          | `Local l0 ->
+            ( match Resolved.find_opt (Ipaddr mx_ipaddr) resolved with
+              | None -> Lwt.return (Resolved.add (Domain (domain, mxs)) (`Local l0) resolved)
+              | Some `All -> Lwt.return resolved
+              | Some (`Local l1) ->
+                let l = List.sort_uniq (Emile.compare_local ~case_sensitive:true) (l0 @ l1) in
+                Lwt.return (Resolved.add (Domain (domain, mxs)) (`Local l) resolved)
+              | Some `Postmaster ->
+                Lwt.return (Resolved.add (Domain (domain, mxs)) (`Local (postmaster :: l0)) resolved) )
+          | `Postmaster -> match Resolved.find_opt (Ipaddr mx_ipaddr) resolved with
+            | Some `Postmaster | Some `All -> Lwt.return resolved
+            | Some (`Local l) -> Lwt.return (Resolved.add (Domain (domain, mxs)) (`Local (postmaster :: l)) resolved)
+            | None -> Lwt.return (Resolved.add (Domain (domain, mxs)) (`Local [ postmaster ]) resolved) in
+    let resolved = By_ipaddr.fold (fun k v m -> Resolved.add (Ipaddr k) v m) resolved Resolved.empty in
+    Lwt_list.fold_left_s fold resolved (By_domain.bindings unresolved) >>= fun resolved ->
+    let resolved = Resolved.bindings resolved in
+    let producers, targets =
+      List.fold_left (fun (producers, targets) target ->
+          let stream, producer = Lwt_stream.create () in
+          let stream () = Lwt_scheduler.inj (Lwt_stream.get stream) in
+          (producer :: producers), (stream, target) :: targets)
+        ([], []) resolved in
+    let transmit = plug_consumer_to_producers consumer producers in
+    let emitter, _ = Ptt.Messaged.from key and id = Ptt.Messaged.id key in
+    let sendmails =
+      let sendmail (stream, (k, vs)) () =
+        let open Colombe in
+        let open Forward_path in
+        let mx_domain, mxs = match k with
+          | Ipaddr ((Ipaddr.V4 v4) as mx_ipaddr) -> Domain.IPv4 v4, Mxs.(singleton (v ~preference:0 mx_ipaddr))
+          | Ipaddr ((Ipaddr.V6 v6) as mx_ipaddr) -> Domain.IPv6 v6, Mxs.(singleton (v ~preference:0 mx_ipaddr))
+          | Domain (mx_domain, mxs) -> Domain.Domain (Domain_name.to_strings mx_domain), mxs in
+        let recipients = match vs with
+          | `All -> [ Domain mx_domain ]
+          | `Local vs ->
+            List.map (fun local ->
+                let local = `Dot_string (List.map (function `Atom x -> x | `String x -> x) local) in
+                Forward_path { Path.local= local; Path.domain= mx_domain; Path.rest= []; }) vs in
+        Log.info (fun m -> m "Start to send the email %Ld to %a" id Colombe.Domain.pp mx_domain) ;
+        let rec go = function
+          | [] ->
+            Log.err (fun m -> m "Impossible to send the email %Ld to %a."
+                        id Colombe.Domain.pp mx_domain) ;
+            Lwt.return ()
+          | { Mxs.mx_ipaddr= Ipaddr.V6 _; _ } :: rest -> go rest
+            (* XXX(dinosaure): we completely ignore IPv6 when the current stack is only for V4. *)
+          | { Mxs.mx_ipaddr= Ipaddr.V4 mx_ipaddr; _ } :: rest ->
+            sendmail stack conf_server mx_ipaddr emitter stream recipients >>= function
+            | Ok () ->
+              Log.info (fun m -> m "Email %Ld correctly sended to domain %a [%a]"
+                           id Colombe.Domain.pp mx_domain Ipaddr.V4.pp mx_ipaddr) ;
+              Lwt.return ()
+            | Error err ->
+              Log.err (fun m -> m "Got an error while sending email %Ld to %a: %a"
+                          id Ipaddr.V4.pp mx_ipaddr Tuyau_mirage.pp_error err) ;
+              go rest in
+        let sort = List.sort (fun { Mxs.preference= a; _ } { Mxs.preference= b; _ } -> Int.compare a b) in
+        go (Mxs.elements mxs |> sort) in
+      List.map sendmail targets in
+    Lwt.join (List.map (apply ()) (transmit :: sendmails)) >>= fun () ->
+    Log.info (fun m -> m "Transmission of the mail %Ld correctly done." id ) ;
+    Relay.Md.close queue
+
+  let smtp_relay_service resolver conf conf_server =
+    Tuyau_mirage.impl_of_service ~key:TCP.configuration TCP.service |> Lwt.return >>? fun (module Server) ->
+    Tuyau_mirage.serve ~key:TCP.configuration conf ~service:TCP.service >>? fun (t, protocol) ->
+    let handle ip port (Tuyau_mirage.Flow (flow, (module Flow))) () =
+      let rdwr = rdwr_of_flow (module Flow) in
+      Lwt.catch
+        (fun () -> Relay.accept rdwr flow resolver conf_server >|= R.reword_error (R.msgf "%a" Relay.pp_error) >>? fun () ->
+          (* TODO(dinosaure): [Flow.close] is called only if [Relay.accept] returns [Ok]. *)
+          Flow.close flow >|= R.reword_error (R.msgf "%a" Flow.pp_error) )
+        (function Failure err -> Lwt.return (R.error_msg err)
+                | exn -> Lwt.return (Error (`Exn exn))) >>= function
+      | Ok () ->
+        Log.info (fun m -> m "<%a:%d> submitted a message." Ipaddr.V4.pp ip port) ;
+        Lwt.return ()
+      | Error (`Msg err) ->
+        Log.err (fun m -> m "<%a:%d> %s" Ipaddr.V4.pp ip port err) ;
+        Lwt.return ()
+      | Error (`Exn exn) ->
+        Log.err (fun m -> m "<%a:%d> raised an unknown exception: %s" Ipaddr.V4.pp ip port (Printexc.to_string exn)) ;
+        Lwt.return () in
+    let rec go () =
+      Server.accept t >>? fun flow ->
+      let ip, port = TCP.dst flow in
+      let flow = Tuyau_mirage.abstract protocol flow in
+      Lwt.async (handle ip port flow) ; Lwt.pause () >>= go in
+    go () >|= R.reword_error (R.msgf "%a" Server.pp_error)
+
+  let smtp_relay_service resolver conf conf_server =
+    smtp_relay_service resolver conf conf_server >>= function
+    | Ok () -> Lwt.return ()
+    | Error err ->
+      Log.err (fun m -> m "%a" Tuyau_mirage.pp_error err) ;
+      Lwt.return ()
+
+  let smtp_logic stack resolver conf_server messaged map =
+    let rec go () =
+      Relay.Md.await messaged >>= fun () ->
+      Relay.Md.pop messaged >>= function
+      | None -> Lwt.pause () >>= go
+      | Some v -> Lwt.async (fun () -> transmit stack resolver conf_server map v) ; Lwt.pause () >>= go in
+    go ()
+
+  let fiber stack resolver conf map info =
+    let conf_server = Relay.create ~info dns_impl in
+    let messaged = Relay.messaged conf_server in
+    Lwt.join [ smtp_relay_service resolver conf conf_server
+             ; smtp_logic stack resolver conf_server messaged map
+             ; Nocrypto_entropy_lwt.initialize () ]
+end
+
+module Server = Make(Tcpip_stack_socket)
 
 let load_file filename =
   let open Rresult in
@@ -51,103 +312,32 @@ let private_key =
 
 let private_key = Rresult.R.get_ok private_key
 
-let info =
-  { Relay.domain= Colombe.Domain.(v domain [ a "x25519"; a "net" ])
-  ; Relay.ipv4= Ipaddr.V4.any
-  ; Relay.tls= Tls.Config.server ~certificates:(`Single ([ cert ], private_key)) ~authenticator:X509.Authenticator.null () (* lol *)
-  ; Relay.size= 0x1000000L }
+let fiber ~domain map =
+  Tcpip_stack_socket.TCPV4.connect None >>= fun tcpv4 ->
+  Tcpip_stack_socket.UDPV4.connect None >>= fun udpv4 ->
+  Tcpip_stack_socket.connect [] udpv4 tcpv4 >>= fun stackv4 ->
+  let conf =
+    { Tuyau_mirage_tcp.stack= stackv4
+    ; Tuyau_mirage_tcp.keepalive= None
+    ; Tuyau_mirage_tcp.port= 4242 } in
+  let info =
+    { Relay.domain
+    ; Relay.ipv4= Ipaddr.V4.any
+    ; Relay.tls= Tls.Config.server ~certificates:(`Single ([ cert ], private_key)) ~authenticator:X509.Authenticator.null ()
+    ; Relay.size= 0x1000000L } in
+  let resolver = Server.DNS.create stackv4 in
+  Server.fiber stackv4 resolver conf map info
 
-let pp_edn ppf = function
-  | Unix.ADDR_UNIX v -> Fmt.pf ppf "<unix:%s>" v
-  | Unix.ADDR_INET (inet, p) -> Fmt.pf ppf "<inet:%s:%d>" (Unix.string_of_inet_addr inet) p
+let romain_calascibetta =
+  let open Mrmime.Mailbox in
+  Local.[ w "romain"; w "calascibetta" ] @ Domain.(domain, [ a "gmail"; a "com" ])
 
-let loop_server sockaddr resolver server =
-  let open Lwt.Infix in
-  let master = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
-  Lwt_unix.bind master sockaddr >>= fun () ->
-  Fmt.pr ">>> server on %a.\n%!" pp_edn sockaddr ;
-  let go socket edn () =
-    Fmt.epr ">>> accept from %a.\n%!" pp_edn edn ;
-    Relay.accept rdwr socket resolver server >>= function
-    | Ok () -> Lwt_unix.close socket
-    | Error err ->
-      Fmt.epr "[ERROR]: from %a: %a.\n%!" pp_edn edn Relay.pp_error err ;
-      Lwt_unix.close socket in
-  let rec loop () =
-    Lwt_unix.accept master >>= fun (socket, edn) ->
-    Lwt.async (go socket edn) ; Lwt.pause () >>= loop in
-  Lwt_unix.listen master 40 ; loop ()
-
-module Lwt_io : Sage_lwt.SYSCALL with type path = string = struct
-  type path = string
-  type t = string * Lwt_unix.file_descr
-
-  open Lwt.Infix
-
-  let open_ro path =
-    Lwt_unix.(openfile path [ O_RDONLY ] 0o644) >>= fun fd ->
-    Lwt.return (path, fd)
-  let open_wo path =
-    Lwt_unix.(openfile path [ O_WRONLY; O_CREAT ] 0o644) >>= fun fd ->
-    Lwt.return (path, fd)
-
-  let length (path, _) =
-    let open Lwt.Infix in
-    Lwt_unix.stat path >>= fun stat ->
-    Lwt.return (Int64.of_int stat.Lwt_unix.st_size)
-
-  let read (_, fd) buf ~off ~len =
-    Lwt_unix.read fd buf off len
-
-  let write (_, fd) buf ~off ~len =
-    Lwt_unix.write fd buf off len
-
-  let close (_, fd) = Lwt_unix.close fd
-end
-
-let record_to_file path consumer =
-  let consumer = Sage.v <.> Sage_lwt.inj <.> consumer in
-  let open Sage in
-  let rec go () =
-    let* v = consumer () in
-    match v with
-    | None -> close
-    | Some (buf, off, len) ->
-      let* _len = write (Bytes.unsafe_of_string buf) ~off ~len in
-      go () in
-  let* () = open_file wo ~path in go ()
-
-let loop_logic messaged =
-  let open Lwt.Infix in
-  let go key queue consumer () =
-    let path = Fmt.strf "%04Ld.mail" (Ptt.Messaged.id key) in
-    Sage_lwt.run (module Lwt_io) Sage.closed (record_to_file path consumer) >>= fun (s, ()) ->
-    match Sage.is_closed s with
-    | Some Sage.Refl.Refl ->
-      Relay.Md.close queue
-    | None ->
-      Fmt.epr ">>> %s is not properly closed.\n%!" path ;
-      Relay.Md.close queue in
-  let rec loop () =
-    Relay.Md.await messaged >>= fun () ->
-    Relay.Md.pop messaged >>= function
-    | None -> Lwt.pause () >>= loop
-    | Some (key, queue, consumer) ->
-      Lwt.async (go key queue consumer) ; Lwt.pause () >>= loop in
-  loop ()
-
-let fiber r sockaddr =
-  let server = Relay.create ~info resolver in
-  let messaged = Relay.messaged server in
-  Lwt.join [ loop_server sockaddr r server
-           ; loop_logic messaged
-           ; Nocrypto_entropy_lwt.initialize () ]
-
-let r = Dns_client_lwt.create ~clock:(Mtime.to_uint64_ns <.> Mtime_clock.now) ()
-
-let sockaddr =
-  let { Unix.h_addr_list; _ } = Unix.gethostbyname (Unix.gethostname ()) in
-  Unix.ADDR_INET (h_addr_list.(0), 4242)
-
-let () = Lwt_main.run (fiber r sockaddr)
-
+let () =
+  let domain = Domain_name.(host_exn <.> of_string_exn) "x25519.net" in
+  let map = Ptt.Relay_map.empty ~postmaster:romain_calascibetta ~domain in
+  let map =
+    let open Mrmime.Mailbox in
+    Ptt.Relay_map.add
+      ~local:(Local.(v [ w "romain"; w "calascibetta" ]))
+      romain_calascibetta map in
+  Lwt_main.run (fiber ~domain map)

--- a/lib/aggregate.ml
+++ b/lib/aggregate.ml
@@ -1,0 +1,63 @@
+let ( <.> ) f g = fun x -> f (g x)
+
+module By_domain = Map.Make(struct type t = [ `host ] Domain_name.t let compare = Domain_name.compare end)
+module By_ipaddr = Map.Make(Ipaddr)
+
+type unresolved_elt = [ `All | `Postmaster | `Local of Emile.local list ]
+type resolved_elt = [ `All | `Local of Emile.local list ]
+
+let postmaster = [ `Atom "Postmaster" ]
+let equal_local = Emile.equal_local ~case_sensitive:true
+
+let add_unresolved ~domain elt unresolved =
+  match elt, By_domain.find_opt domain unresolved with
+  | `All, _ -> By_domain.add domain `All unresolved
+  | _, Some `All | `Postmaster, Some `Postmaster -> unresolved
+  | `Postmaster, Some (`Local vs) ->
+    if List.exists (equal_local postmaster) vs
+    then unresolved
+    else By_domain.add domain (`Local (postmaster :: vs)) unresolved
+  | `Local v, Some (`Local vs) ->
+    if List.exists (equal_local v) vs
+    then unresolved
+    else By_domain.add domain (`Local (v :: vs)) unresolved
+  | `Local v, Some `Postmaster ->
+    By_domain.add domain (`Local [ v; postmaster; ]) unresolved
+  | `Postmaster, None -> By_domain.add domain `Postmaster unresolved
+  | `Local v, None -> By_domain.add domain (`Local [ v ]) unresolved
+
+let add_resolved ipaddr elt resolved =
+  match elt, By_ipaddr.find_opt ipaddr resolved with
+  | `All, _ -> By_ipaddr.add ipaddr `All resolved
+  | _, Some `All -> resolved
+  | `Local v, Some (`Local vs) ->
+    if List.exists (equal_local v) vs
+    then resolved else By_ipaddr.add ipaddr (`Local (v :: vs)) resolved
+  | `Local v, None ->
+    By_ipaddr.add ipaddr (`Local [ v ]) resolved
+
+let aggregate_by_domains ~domain =
+  let open Colombe in
+  let open Forward_path in
+  let fold (unresolved, resolved) = function
+    | Postmaster ->
+      add_unresolved ~domain `Postmaster unresolved, resolved
+    | Forward_path { Path.domain= Domain.Domain v; Path.local; _ } ->
+      let domain = Domain_name.(host_exn <.> of_strings_exn) v in
+      let local = Colombe_emile.of_local local in
+      add_unresolved ~domain (`Local local) unresolved, resolved
+    | Domain (Domain.Domain v) ->
+      let domain = Domain_name.(host_exn <.> of_strings_exn) v in
+      add_unresolved ~domain `All unresolved, resolved
+    | Domain (Domain.IPv4 v4) -> unresolved, add_resolved (Ipaddr.V4 v4) `All resolved
+    | Domain (Domain.IPv6 v6) -> unresolved, add_resolved (Ipaddr.V6 v6) `All resolved
+    | Forward_path { Path.domain= Domain.IPv4 v4; Path.local; _ } ->
+      let local = Colombe_emile.of_local local in
+      unresolved, add_resolved (Ipaddr.V4 v4) (`Local local) resolved
+    | Forward_path { Path.domain= Domain.IPv6 v6; Path.local; _ } ->
+      let local = Colombe_emile.of_local local in
+      unresolved, add_resolved (Ipaddr.V6 v6) (`Local local) resolved
+    | Domain (Domain.Extension _)
+    | Forward_path { Path.domain= Domain.Extension _; _ } ->
+      unresolved, resolved in (* TODO *)
+  List.fold_left fold (By_domain.empty, By_ipaddr.empty)

--- a/lib/aggregate.mli
+++ b/lib/aggregate.mli
@@ -1,0 +1,9 @@
+module By_domain : Map.S with type key = [ `host ] Domain_name.t
+module By_ipaddr : Map.S with type key = Ipaddr.t
+
+type unresolved_elt = [ `All | `Postmaster | `Local of Emile.local list ]
+type resolved_elt = [ `All | `Local of Emile.local list ]
+
+val add_unresolved : domain:[ `host ] Domain_name.t -> [ `All | `Postmaster | `Local of Emile.local ] -> unresolved_elt By_domain.t -> unresolved_elt By_domain.t
+val add_resolved : Ipaddr.t -> [ `All | `Local of Emile.local ] -> resolved_elt By_ipaddr.t -> resolved_elt By_ipaddr.t
+val aggregate_by_domains : domain:[ `host ] Domain_name.t -> Colombe.Forward_path.t list -> (unresolved_elt By_domain.t * resolved_elt By_ipaddr.t)

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name ptt)
- (libraries sendmail.tls emile ke psq logs colombe))
+ (libraries colombe.emile domain-name dns sendmail.tls emile ke psq logs colombe))

--- a/lib/messaged.ml
+++ b/lib/messaged.ml
@@ -4,7 +4,7 @@ open Colombe
 module Ke = Ke.Rke.Weighted
 
 type from = Reverse_path.t * (string * string option) list
-type recipient = Ipaddr.t * Forward_path.t * (string * string option) list
+type recipient = Forward_path.t * (string * string option) list
 
 type key =
   { domain_from : Domain.t
@@ -77,7 +77,7 @@ module Make
         return ()
       | Some (buf, off, len) as v ->
         Mutex.lock mutex >>= fun () ->
-        if !close then return ()
+        if !close then ( Mutex.unlock mutex ; return () )
         else match Ke.N.push queue ~blit:blit_of_string ~length:String.length ~off ~len buf with
         | None ->
           Condition.signal condition ; Mutex.unlock mutex ; producer v

--- a/lib/messaged.mli
+++ b/lib/messaged.mli
@@ -2,7 +2,7 @@ open Sigs
 open Colombe
 
 type from = Reverse_path.t * (string * string option) list
-type recipient = Ipaddr.t * Forward_path.t * (string * string option) list
+type recipient = Forward_path.t * (string * string option) list
 
 type key
 

--- a/lib/mxs.ml
+++ b/lib/mxs.ml
@@ -1,0 +1,20 @@
+type elt =
+  { preference : int
+  ; mx_ipaddr : Ipaddr.t
+  ; mx_domain : [ `host ] Domain_name.t option }
+
+module Elt = struct
+  type t = elt
+
+  let compare
+      { mx_ipaddr= a; _ }
+      { mx_ipaddr= b; _ } =
+    Ipaddr.compare a b
+end
+
+include (Set.Make(Elt) : Set.S with type elt := elt)
+
+let v ~preference ?domain ipaddr =
+  { preference
+  ; mx_domain= domain
+  ; mx_ipaddr= ipaddr }

--- a/lib/mxs.mli
+++ b/lib/mxs.mli
@@ -1,0 +1,15 @@
+(** A domain can have several Mail eXchange services ordered by
+    a preference number. The lower preference is a higher priority.
+    This module provides a way to store them. The uniq identifier for
+    each MX value is the [Ipaddr.V4.t]. *)
+
+type elt =
+  { preference : int
+  ; mx_ipaddr : Ipaddr.t
+  ; mx_domain : [ `host ] Domain_name.t option }
+(** Type of a MX value. *)
+
+val v : preference:int -> ?domain:[ `host ] Domain_name.t -> Ipaddr.t -> elt
+(** [v ~preference ?domain mx_ipaddr] returns an MX value. *)
+
+include Set.S with type elt := elt

--- a/lib/ptt.ml
+++ b/lib/ptt.ml
@@ -1,2 +1,6 @@
+module SMTP = SMTP
 module Relay = Relay
+module Relay_map = Relay_map
 module Messaged = Messaged
+module Mxs = Mxs
+module Aggregate = Aggregate

--- a/lib/relay.mli
+++ b/lib/relay.mli
@@ -1,4 +1,5 @@
 open Colombe.Sigs
+open Rresult
 open Sigs
 
 module Make
@@ -8,14 +9,20 @@ module Make
     module Md : module type of Messaged.Make(Scheduler)(IO)
 
     type 'r resolver =
-      { gethostbyname : 'a. 'r -> [ `host ] Domain_name.t -> (Ipaddr.V4.t, [> Rresult.R.msg ] as 'a) result IO.t
-      ; extension : 'a. string -> string -> (Ipaddr.t, [> Rresult.R.msg ] as 'a) result IO.t }
+      { gethostbyname : 'a. 'r -> [ `host ] Domain_name.t -> (Ipaddr.V4.t, [> R.msg ] as 'a) result IO.t
+      ; getmxbyname : 'a. 'r -> [ `host ] Domain_name.t -> (Dns.Rr_map.Mx_set.t, [> R.msg ] as 'a) result IO.t
+      ; extension : 'a. string -> string -> (Ipaddr.V4.t, [> R.msg ] as 'a) result IO.t }
+
     type 'r server
+
     type info = SMTP.info =
-      { domain : Colombe.Domain.t
+      { domain : [ `host ] Domain_name.t
       ; ipv4 : Ipaddr.V4.t
       ; tls : Tls.Config.server
       ; size : int64 }
+
+    val info : 'r server -> info
+    val resolver : 'r server -> 'r resolver
 
     type error
 

--- a/lib/relay_map.ml
+++ b/lib/relay_map.ml
@@ -1,0 +1,79 @@
+type t =
+  { postmaster : Emile.mailbox
+  ; domain : [ `host ] Domain_name.t
+  ; map : (Emile.local, Colombe.Forward_path.t list) Hashtbl.t }
+
+let postmaster { postmaster; _ } = postmaster
+let domain { domain; _ } = domain
+
+let empty ~postmaster ~domain =
+  { postmaster
+  ; domain
+  ; map= Hashtbl.create 256 }
+
+let add ~local mailbox t =
+  match Colombe_emile.to_forward_path mailbox with
+  | Error (`Msg err) -> invalid_arg err
+  | Ok mailbox ->
+    try let rest = Hashtbl.find t.map local in
+      if not (List.exists (Colombe.Forward_path.equal mailbox) rest)
+      then Hashtbl.add t.map local (mailbox :: rest) ; t
+    with Not_found ->
+      Hashtbl.add t.map local [ mailbox ] ; t
+
+let recipients ~local { map; _ } =
+  match Hashtbl.find map local with
+  | recipients -> recipients
+  | exception Not_found -> []
+
+let all t =
+  Hashtbl.fold (fun _ vs a -> vs @ a) t.map []
+
+let ( <.> ) f g = fun x -> f (g x)
+
+let expand t unresolved resolved =
+  let open Aggregate in
+  let fold domain elt (unresolved, resolved) =
+    if not (Domain_name.equal domain t.domain)
+    then By_domain.add domain elt unresolved, resolved
+    else
+      let open Colombe in
+      let open Forward_path in
+      let fold (unresolved, resolved) = function
+        | Postmaster ->
+          let local = t.postmaster.Emile.local in
+          let domain, _ = t.postmaster.Emile.domain in
+          ( match domain with
+            | `Domain vs ->
+              let domain = Domain_name.(host_exn <.> of_strings_exn) vs in
+              add_unresolved ~domain `Postmaster unresolved, resolved
+            | `Addr (Emile.IPv4 v4) -> unresolved, add_resolved (Ipaddr.V4 v4) (`Local local) resolved
+            | `Addr (Emile.IPv6 v6) -> unresolved, add_resolved (Ipaddr.V6 v6) (`Local local) resolved
+            | `Addr (Emile.Ext _) | `Literal _ -> unresolved, resolved )
+        | Domain (Domain.Domain v) ->
+          let domain = Domain_name.(host_exn <.> of_strings_exn) v in
+          add_unresolved ~domain `All unresolved, resolved
+        | Forward_path { Path.domain= Domain.Domain v; Path.local; _ } ->
+          let domain = Domain_name.(host_exn <.> of_strings_exn) v in
+          let local = Colombe_emile.of_local local in
+          add_unresolved ~domain (`Local local) unresolved, resolved
+        | Forward_path { Path.domain= Domain.IPv4 v4; Path.local; _ } ->
+          let local = Colombe_emile.of_local local in
+          unresolved, add_resolved (Ipaddr.V4 v4) (`Local local) resolved
+        | Forward_path { Path.domain= Domain.IPv6 v6; Path.local; _ } ->
+          let local = Colombe_emile.of_local local in
+          unresolved, add_resolved (Ipaddr.V6 v6) (`Local local) resolved
+        | Domain (Domain.IPv4 v4) -> unresolved, add_resolved (Ipaddr.V4 v4) `All resolved
+        | Domain (Domain.IPv6 v6) -> unresolved, add_resolved (Ipaddr.V6 v6) `All resolved
+        | Forward_path { Path.domain= Domain.Extension _; _ } -> unresolved, resolved
+        | Domain (Domain.Extension _) -> unresolved, resolved in
+      match elt with
+      | `Postmaster ->
+        List.fold_left fold (unresolved, resolved) [ Postmaster ]
+      | `All ->
+        List.fold_left fold (unresolved, resolved) (all t)
+      | `Local vs ->
+        let vs = List.fold_left (fun a local -> recipients ~local t @ a) [] vs in
+        List.fold_left fold (unresolved, resolved) vs in
+  By_domain.fold fold unresolved (By_domain.empty, resolved)
+

--- a/lib/relay_map.mli
+++ b/lib/relay_map.mli
@@ -1,0 +1,36 @@
+(** The {i relay-map} allows the user to map an user from a
+    specific domain to some others mailboxes. Like:
+
+    Any incoming emails to john@doe.org will be send to:
+    {ul
+    {- john@gmail.com}
+    {- john@wanadoo.fr}}
+
+    To be able to do that, the user must create a {i relay-map} with
+    {!empty}: [empty ~postmaster ~domain:"doe.org"] and fills the map
+    with [add ~local:"john" "john@gmail.com" |> add ~local:"john" "john@wanadoo.fr"]. *)
+
+type t
+(** The type of the map. *)
+
+val postmaster : t -> Emile.mailbox
+(** [postmaster m] returns the {i postmaster} of the map which {b is} the postmaster
+   of {!domain}'s [m]. *)
+                        
+val domain : t -> [ `host ] Domain_name.t
+(** [domain m] returns the domain handled by [m]. *)
+
+val empty : postmaster:Emile.mailbox -> domain:[ `host ] Domain_name.t -> t
+(** [empty ~postmaster ~domain] creates a map which handles the given [domain]. *)
+
+val add : local:Emile.local -> Emile.mailbox -> t -> t
+(** [add ~local mailbox m] appends a new deliver mailbox to [local] into [m]. *)
+
+val recipients : local:Emile.local -> t -> Colombe.Forward_path.t list
+(** [recipients ~local m] returns all associated mailboxes to [local] in [m]. *)
+
+val all : t -> Colombe.Forward_path.t list
+(** [all m] returns all deliver mailboxes registered into [m]. *)
+
+val expand : t -> Aggregate.unresolved_elt Aggregate.By_domain.t -> Aggregate.resolved_elt Aggregate.By_ipaddr.t ->
+  (Aggregate.unresolved_elt Aggregate.By_domain.t * Aggregate.resolved_elt Aggregate.By_ipaddr.t)

--- a/lib/sMTP.mli
+++ b/lib/sMTP.mli
@@ -62,7 +62,7 @@ module Monad : module type of State.Scheduler(Sendmail_with_tls.Context_with_tls
 type context = Sendmail_with_tls.Context_with_tls.t
 
 type info =
-  { domain : Domain.t
+  { domain : [ `host ] Domain_name.t
   ; ipv4 : Ipaddr.V4.t
   ; tls : Tls.Config.server
   ; size : int64 }
@@ -78,8 +78,8 @@ type error = Value_with_tls.error
 
 val pp_error : error Fmt.t
 
-val properly_close_and_fail : context -> ?code:int -> message:string -> error -> (unit, error) Colombe.State.t
-val politely_close : context -> ([> `Quit ], error) Colombe.State.t
+val m_properly_close_and_fail : context -> ?code:int -> message:string -> error -> (unit, error) Colombe.State.t
+val m_politely_close : context -> ([> `Quit ], error) Colombe.State.t
 
 val m_relay : context -> domain_from:Domain.t -> ([> `Quit | `Submission of submission ], error) Colombe.State.t
 val m_mail  : context -> (unit, error) Colombe.State.t


### PR DESCRIPTION
This PR is not very well documented but it bootstraps a full implementation of a SMTP relay. The goal (available on the `bin/` directory) shows how to launch a SMTP relay with a map of a (probably?) local domain-name.

Use this SMTP server as a SMTP server which will handle incoming emails will just translate recipients of the given domain-name to real recipients - like `romain@x25519.net` to `romain.calascibetta@gmail.com`.

For others, it does what an usual SMTP server does: re-transmits the incoming email to destination. 