### PR TITLE
Limit concurrent connections handled by the server

### DIFF
--- a/lib/ptt_tuyau.ml
+++ b/lib/ptt_tuyau.ml
@@ -104,45 +104,24 @@ module Server (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) = struct
 
   type service = {
       stack: Stack.t
-    ; queue: Stack.TCP.flow Queue.t
-    ; condition: unit Lwt_condition.t
-    ; mutex: Lwt_mutex.t
-    ; mutable closed: bool
+    ; consumer: Stack.TCP.flow Lwt_stream.t
+    ; producer: Stack.TCP.flow Lwt_stream.bounded_push
   }
 
   let init ~port stack =
-    let queue = Queue.create () in
-    let condition = Lwt_condition.create () in
-    let mutex = Lwt_mutex.create () in
-    let listener flow =
-      Lwt_mutex.lock mutex >>= fun () ->
-      Queue.push flow queue
-      ; Lwt_condition.signal condition ()
-      ; Lwt_mutex.unlock mutex
-      ; Lwt.return () in
+    let consumer, producer = Lwt_stream.create_bounded 10 in
+    let listener flow = producer#push flow in
     Stack.listen_tcp ~port stack listener
-    ; Lwt.return {stack; queue; condition; mutex; closed= false}
+    ; Lwt.return {stack; consumer; producer}
 
-  let rec accept ({queue; condition; mutex; _} as t) =
-    Lwt_mutex.lock mutex >>= fun () ->
-    let rec await () =
-      if Queue.is_empty queue && not t.closed then
-        Lwt_condition.wait condition ~mutex >>= await
-      else Lwt.return_unit in
-    await () >>= fun () ->
-    match Queue.pop queue with
-    | flow -> Lwt_mutex.unlock mutex ; Lwt.return_ok flow
-    | exception Queue.Empty ->
-      if t.closed then (
-        Lwt_mutex.unlock mutex
-        ; Lwt.return_error `Closed)
-      else (Lwt_mutex.unlock mutex ; accept t)
+  let rec accept ({consumer; producer; _} as t) =
+    Lwt_stream.get consumer >>= function
+    | Some flow -> Lwt.return_ok flow
+    | None when producer#closed -> Lwt.return_error `Closed
+    | None -> accept t
 
-  let close ({stack; condition; _} as t) =
-    t.closed <- true
-    ; Stack.disconnect stack >>= fun () ->
-      Lwt_condition.signal condition ()
-      ; Lwt.return_unit
+  let close {stack; producer; _} =
+    Stack.disconnect stack >>= fun () -> producer#close ; Lwt.return_unit
 
   let ( >>? ) = Lwt_result.bind
 


### PR DESCRIPTION
An other `Out_of_memory` vector is the number of concurrent connections handled by the server which is unlimited. In a restrained context, we are not able to limit to an upper bound how many connection  we want to handle (and how many internal buffers transitively are alive).

This PR limit with `Lwt_stream.create_bounded` the number of concurrent connections to let the opportunity to:
1) free internal buffers
2) keep a stable memory consumption even if the server must handle more than 10 connections - others connections must wait.